### PR TITLE
fix a typo

### DIFF
--- a/colwise.Rmd
+++ b/colwise.Rmd
@@ -567,7 +567,7 @@ tb <- tibble(
 )
 ```
 
-如果想显示列表中每个元素的长度，用purrr包，可以这样写
+如果想显示列表中某个元素中每个元素的长度，用purrr包，可以这样写
 ```{r}
 tb %>% mutate(l = purrr::map_int(x, length))
 ```


### PR DESCRIPTION
列表的元素应该是向量，这里每个元素的长度应该是6。
```{r}
> purrr::map_int(df,length)
##  id  w  x  y  z 
##   6  6  6  6  6
```